### PR TITLE
prevent Safari iOS from zooming on input focus

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -535,6 +535,9 @@
                 }
             }
         }
+        #search {
+            font-size:16px;
+        }
     }
 
     .item-desc .helper {


### PR DESCRIPTION
Increase search input font size to 16px to prevent Safari iOS from zooming in on input (which is undesirable and annoying for a mobile site) Thanks!